### PR TITLE
Update example reference data for 2024/24

### DIFF
--- a/aocd_example_parser/examples.json
+++ b/aocd_example_parser/examples.json
@@ -2734,6 +2734,12 @@
       "input_data": "a_pre[-2]",
       "answer_a":   "a_code[-2]",
       "answer_b":   "None"
+    },
+    {
+      "input_data": "b_pre[-2]",
+      "answer_a":   "None",
+      "answer_b":   "b_code[-11]",
+      "extra":      {"n_swapped_pairs": 2, "operation": "bitwise_and"}
     }
   ]
 }

--- a/aocd_example_parser/examples.json
+++ b/aocd_example_parser/examples.json
@@ -2732,7 +2732,8 @@
     },
     {
       "input_data": "a_pre[-2]",
-      "answer_a":   "a_code[-2]"
+      "answer_a":   "a_code[-2]",
+      "answer_b":   "None"
     }
   ]
 }

--- a/aocd_example_parser/examples.json
+++ b/aocd_example_parser/examples.json
@@ -2724,5 +2724,15 @@
     {
       "answer_a":   "a_code[-3]"
     }
+  ],
+  "2024/24":  [
+    {
+      "answer_a":   "a_code[-8]",
+      "answer_b":   "None"
+    },
+    {
+      "input_data": "a_pre[-2]",
+      "answer_a":   "a_code[-2]"
+    }
   ]
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "aocd-example-parser"
-version = "2024.12.23"
+version = "2024.12.24"
 description = "Implementation of example parser plugins for advent-of-code-data"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
An update to add example reference data for 2024/24. I put two examples, leaving the simpler one first. Part B has no example. Although `b_pre[-2]` with answer `b_code[-11]` might fit the bill, the operation simulated is a bitwise and versus the adder.